### PR TITLE
Fix middleware install target

### DIFF
--- a/middleware/v2/Makefile
+++ b/middleware/v2/Makefile
@@ -64,19 +64,9 @@ install:
 ifneq ($(FLASH_SIZE_SHRINK),y)
 	# copy sample_xxx
 	@cp -f sample/mipi_tx/sample_dsi $(DESTDIR)/usr/bin
-	@cp -f sample/cipher/sample_cipher $(DESTDIR)/usr/bin
-	@cp -f sample/cvg/sample_cvg $(DESTDIR)/usr/bin
 	@cp -f sample/venc/sample_venc $(DESTDIR)/usr/bin
 	@cp -f sample/venc/sample_vcodec $(DESTDIR)/usr/bin
 	@cp -f sample/vdec/sample_vdec $(DESTDIR)/usr/bin
-endif
-
-ifneq ($(FLASH_SIZE_SHRINK),y)
-	# copy venc
-	@cp -f modules/venc/vc_lib/bin/cvi_h265_enc_test $(DESTDIR)/usr/bin
-	@cp -f modules/venc/vc_lib/bin/cvi_h265_dec $(DESTDIR)/usr/bin
-	@cp -f modules/venc/vc_lib/bin/cvi_h264_dec $(DESTDIR)/usr/bin
-	@cp -f modules/venc/vc_lib/bin/cvi_jpg_codec $(DESTDIR)/usr/bin
 endif
 
 ifneq ($(FLASH_SIZE_SHRINK),y)


### PR DESCRIPTION
Noticed that some libraries where missing in the image, seems that the install target fails due to some examples that where missing. Removing them from the install target fixed the issue.