### PR TITLE
Free the cvi_wifi_power_gpio when unloading wifi driver

### DIFF
--- a/linux_5.10/drivers/net/wireless/aicsemi/aic8800/aic8800_bsp/aicsdio.c
+++ b/linux_5.10/drivers/net/wireless/aicsemi/aic8800/aic8800_bsp/aicsdio.c
@@ -608,6 +608,7 @@ static void aicbsp_platform_power_off(void)
 			printk("%s: WLAN_POWER output low failed!\n", __func__);
 		}
 	}
+	gpio_free(cvi_wifi_power_gpio);
 #endif //CONFIG_PLATFORM_CVITEK
 
 	sdio_dbg("%s\n", __func__);


### PR DESCRIPTION
This PR is aimed at resolving the issue that the aic8800_fdrv.ko cannot be reloaded once it has been initally installed, and rmmod'd.