### PR TITLE
Fix adb setup via configfs on milkv-duo-256m

### DIFF
--- a/device/generic/br_overlay/common/etc/run_usb.sh
+++ b/device/generic/br_overlay/common/etc/run_usb.sh
@@ -258,16 +258,16 @@ start() {
     if [ -f $ADBD_PATH/adbd ]; then
 	$ADBD_PATH/adbd &
     fi
-  else
-    # Start the gadget driver
-    UDC=`ls /sys/class/udc/ | awk '{print $1}'`
-    echo ${UDC} >$CVI_GADGET/UDC
+    sleep 0.5
   fi
+  # Start the gadget driver
+  UDC=`ls /sys/class/udc/ | awk '{print $1}'`
+  echo ${UDC} >$CVI_GADGET/UDC
 }
 
 stop() {
   if [ -d $CVI_GADGET/configs/c.1/ffs.adb ]; then
-    pkill adbd
+    killall adbd
     rm $CVI_GADGET/configs/c.1/ffs.adb
   else
     echo "" >$CVI_GADGET/UDC


### PR DESCRIPTION
While setting adb via configfs (using the shell script `/etc/run_usb.sh`) on milkv-duo-256m, some errors happen.

I open the following config to activate the adb utilities and compile using the `milkvtech/milkv-duo:latest` docker environment.
```
BR2_PACKAGE_ANDROID_TOOLS=y
BR2_PACKAGE_ANDROID_TOOLS_FASTBOOT=y
BR2_PACKAGE_ANDROID_TOOLS_ADB=y
BR2_PACKAGE_ANDROID_TOOLS_ADBD=y
```

After flashing the image, I use the UART debug console, and execute the following commands:
```shell
$ /etc/run_usb.sh stop
$ /etc/run_usb.sh probe ncm
$ /etc/run_usb.sh probe adb
$ /etc/run_usb.sh start
```
However, when executing `adb devices` in my host computer, it didn't find the device. After debuging, I find out the following errors.

First, in the start function, if the adb is probed, the UDC will not be assigned to the USB gadget.
```shell
if [ -d $CVI_GADGET/functions/ffs.adb ]; then
    ln -s $CVI_GADGET/functions/ffs.adb $CVI_GADGET/configs/c.1
    mkdir /dev/usb-ffs/adb -p
    mount -t functionfs adb /dev/usb-ffs/adb
    if [ -f $ADBD_PATH/adbd ]; then
	$ADBD_PATH/adbd &
    fi
else
    # Start the gadget driver
    UDC=`ls /sys/class/udc/ | awk '{print $1}'`
    echo ${UDC} >$CVI_GADGET/UDC
fi
```

Second, after mounting the adb functionfs, adb will not be intialized immediately and may require some time before it becomes available. While it is possible to check the presence of `/dev/usb-ffs/adb/ep*` to determine if initialization has completed, to avoid potential infinite loops in shell scripts, I instead simply wait for 0.5 seconds.

Last, the shell script uses pkill to kill the adbd in the stop function. However, the pkill isn't included in the default rootfs built by buildroot. I use killall instead.

After these changes, both the ncm and adb work perfectly.