### PR TITLE
fix: replace bare 'make' calls with '$(MAKE)' for proper jobserver in…

### DIFF
--- a/cvi_mpi/Makefile
+++ b/cvi_mpi/Makefile
@@ -9,7 +9,7 @@ include $(PARAM_FILE)
 all: prepare 3rdparty module component sample self_test
 
 module: prepare 3rdparty
-	@make -C modules/
+	@$(MAKE) -C modules/
 
 prepare:
 	@if [ -f "mpi_prepare.mk" ]; then \
@@ -31,7 +31,7 @@ prepare:
 
 sample: module component
 	@if [ -d "sample/" ]; then \
-		make -C sample/; \
+		$(MAKE) -C sample/; \
 	fi
 
 self_test: module sample
@@ -40,11 +40,11 @@ self_test: module sample
 	fi
 
 component:
-	@make -C component/isp/ all
+	@$(MAKE) -C component/isp/ all
 
 dl_daemon: sample
 	@cmake self_test/dl_daemon -Bself_test/dl_daemon/build
-	@make -C self_test/dl_daemon/build/
+	@$(MAKE) -C self_test/dl_daemon/build/
 
 ifneq ($(SUBTYPE), fpga)
 install:
@@ -101,10 +101,10 @@ package:
 endif
 
 clean:
-	@make -C modules/ clean
-	@make -C 3rdparty/ clean
-	@make -C sample/ clean
-	@make -C component/isp/ clean
+	@$(MAKE) -C modules/ clean
+	@$(MAKE) -C 3rdparty/ clean
+	@$(MAKE) -C sample/ clean
+	@$(MAKE) -C component/isp/ clean
 	@rm -rf self_test/dl_daemon/build
 	@if [ -d "self_test/" ]; then \
 		make -C self_test/ clean; \
@@ -114,4 +114,4 @@ clean:
 	fi
 
 clean_all:
-	@make -C modules/ clean_all
+	@$(MAKE) -C modules/ clean_all

--- a/cvi_mpi/component/isp/Makefile
+++ b/cvi_mpi/component/isp/Makefile
@@ -7,13 +7,9 @@ endif
 chip_arch = $(shell echo $(CHIP_ARCH) | tr A-Z a-z)
 
 all:
-	@cd common; $(MAKE) all || exit 1; cd ../;
-	pushd sensor/$(chip_arch) && \
-	$(MAKE) all && \
-	popd;
+	@$(MAKE) -C common all || exit 1;
+	@$(MAKE) -C sensor/$(chip_arch) all || exit 1;
 
 clean:
-	@cd common; $(MAKE) clean || exit 1; cd ../;
-	pushd sensor/$(chip_arch) && \
-	$(MAKE) clean && \
-	popd;
+	@$(MAKE) -C common clean || exit 1;
+	@$(MAKE) -C sensor/$(chip_arch) clean || exit 1;

--- a/cvi_mpi/component/isp/sensor/cv180x/Makefile
+++ b/cvi_mpi/component/isp/sensor/cv180x/Makefile
@@ -12,9 +12,7 @@ sensor-y := $(filter-out Makefile Makefile_full, $(notdir $(wildcard $(CURDIR)/*
 endif
 
 define MAKE_SENSOR
-	pushd $(1) && \
-	$(MAKE) all && \
-	popd
+	$(MAKE) -C $(1) all
 endef
 
 .PHONY : prepare clean $(sensor-y)

--- a/cvi_mpi/component/isp/sensor/cv181x/Makefile
+++ b/cvi_mpi/component/isp/sensor/cv181x/Makefile
@@ -12,13 +12,14 @@ sensor-y := $(filter-out Makefile Makefile_full, $(notdir $(wildcard $(CURDIR)/*
 endif
 
 define MAKE_SENSOR
-	pushd $(1) && \
-	$(MAKE) all && \
-	popd
+	$(MAKE) -C $(1) all
 endef
 
 .PHONY : prepare clean $(sensor-y)
-all: prepare $(sensor-y) all_sensor
+.NOTPARALLEL:
+all: prepare
+	@for s in $(sensor-y); do $(MAKE) -C $$s all || exit 1; done
+	@$(MAKE) all_sensor
 
 prepare:
 	@echo "#################################################"

--- a/cvi_mpi/component/isp/sensor/cv182x/Makefile
+++ b/cvi_mpi/component/isp/sensor/cv182x/Makefile
@@ -12,9 +12,7 @@ sensor-y := $(filter-out Makefile Makefile_full, $(notdir $(wildcard $(CURDIR)/*
 endif
 
 define MAKE_SENSOR
-	pushd $(1) && \
-	$(MAKE) all && \
-	popd
+	$(MAKE) -C $(1) all
 endef
 
 .PHONY : prepare clean $(sensor-y)

--- a/cvi_mpi/component/isp/sensor/sg200x/Makefile
+++ b/cvi_mpi/component/isp/sensor/sg200x/Makefile
@@ -12,9 +12,7 @@ sensor-y := $(filter-out Makefile Makefile_full, $(notdir $(wildcard $(CURDIR)/*
 endif
 
 define MAKE_SENSOR
-	pushd $(1) && \
-	$(MAKE) all && \
-	popd
+	$(MAKE) -C $(1) all
 endef
 
 .PHONY : prepare clean $(sensor-y)

--- a/cvi_mpi/modules/audio/Makefile
+++ b/cvi_mpi/modules/audio/Makefile
@@ -310,35 +310,35 @@ $(LIBAUDIO_SO): $(AUDIO_OBJS)
 	@echo -e $(GREEN)[LINK]$(END)[$(notdir $(LD))] $(notdir $@)
 
 libsbc:
-	@cd ./sbc_codec; make all
+	@cd ./sbc_codec ; $(MAKE) all
 
 libvoice_engine:
-	@cd ./audio_codec; make all
+	@cd ./audio_codec ; $(MAKE) all
 
 libvqe:
-	@cd ./audio_vqe; make all
+	@cd ./audio_vqe ; $(MAKE) all
 
 libDnVqe:
-	@cd ./audio_dnvqe; make clean; make all
+	@cd ./audio_dnvqe ; $(MAKE) clean ; $(MAKE) all
 
 libcvi_RES1:
-	@cd ./audio_resample; make clean; make all
+	@cd ./audio_resample ; $(MAKE) clean ; $(MAKE) all
 
 libssp20220128:
 	@echo "build libssp version 20220128"
-	@cd ./algo/SSP_Algorithm_20220128; make clean; make all
+	@cd ./algo/SSP_Algorithm_20220128 ; $(MAKE) clean ; $(MAKE) all
 
 libdnssp:
 	@echo "build libssp2 version 20231218"
-	@cd ./algo/downlink; make clean; make all
+	@cd ./algo/downlink ; $(MAKE) clean ; $(MAKE) all
 
 libsonic:
 	@echo "build libsonic"
-	@cd ./algo/sonic; make clean; make all
+	@cd ./algo/sonic ; $(MAKE) clean ; $(MAKE) all
 
 libaac:
 	@echo "build fakeaac"
-	@cd ./fdk_aac_fake; make clean; make all
+	@cd ./fdk_aac_fake ; $(MAKE) clean ; $(MAKE) all
 
 install:
 	@echo "[audio step]COPY LIB!! "
@@ -359,26 +359,26 @@ clean:
 	@rm -f $(INSTALL_LIBDIR)/libcvi_ssp*
 	@rm -f $(INSTALL_LIBDIR)/libdnvqe*
 	@rm -f $(INSTALL_LIBDIR)/libtinyalsa*
-	@make -C ./fdk_aac_fake clean
+	@$(MAKE) -C ./fdk_aac_fake clean
 	@cd ./src/audio_rpc; rm -f *.o
-	@make -C ./sbc_codec clean
-	@make -C ./audio_codec clean
-	@make -C ./audio_vqe clean
-	@make -C ./algo/SSP_Algorithm_20220128 clean
-	@make -C ./audio_dnvqe clean
-	@make -C ./algo/sonic clean
-	@make -C ./audio_resample clean
+	@$(MAKE) -C ./sbc_codec clean
+	@$(MAKE) -C ./audio_codec clean
+	@$(MAKE) -C ./audio_vqe clean
+	@$(MAKE) -C ./algo/SSP_Algorithm_20220128 clean
+	@$(MAKE) -C ./audio_dnvqe clean
+	@$(MAKE) -C ./algo/sonic clean
+	@$(MAKE) -C ./audio_resample clean
 
 clean_all: clean
 	@rm -rf $(AUDIO_ODIR)
-	@make -C ./fdk_aac_fake clean_all
-	@make -C ./sbc_codec clean_all
-	@make -C ./audio_codec clean_all
-	@make -C ./audio_vqe clean_all
-	@make -C ./algo/SSP_Algorithm_20220128 clean_all
-	@make -C ./algo/downlink clean_all
-	@make -C ./audio_dnvqe clean_all
-	@make -C ./audio_resample clean_all
+	@$(MAKE) -C ./fdk_aac_fake clean_all
+	@$(MAKE) -C ./sbc_codec clean_all
+	@$(MAKE) -C ./audio_codec clean_all
+	@$(MAKE) -C ./audio_vqe clean_all
+	@$(MAKE) -C ./algo/SSP_Algorithm_20220128 clean_all
+	@$(MAKE) -C ./algo/downlink clean_all
+	@$(MAKE) -C ./audio_dnvqe clean_all
+	@$(MAKE) -C ./audio_resample clean_all
 
 prepare:
 	@echo [aduio Start] Timestamp is $(ts)

--- a/cvi_mpi/modules/isp/cv180x/Makefile
+++ b/cvi_mpi/modules/isp/cv180x/Makefile
@@ -16,7 +16,7 @@ all:
 	@cd isp; $(MAKE) all;
 	@cd isp_bin; $(MAKE) all;
 	@cd $(ISP_COMMON_DIR)/toolJsonGenerator; ./generate_toolJson.sh $(shell echo $(CHIP_ARCH) | tr A-Z a-z)
-	@cd isp-daemon2; $(MAKE) -j4; $(MAKE) install;
+	@cd isp-daemon2; $(MAKE); $(MAKE) install;
 	@cd $(ISP_COMMON_DIR)/raw_replay; $(MAKE) all;
 	@cd $(ISP_COMMON_DIR)/raw_dump; $(MAKE) all;
 
@@ -44,10 +44,10 @@ clean:
 	@cd $(ISP_COMMON_DIR)/raw_dump; $(MAKE) clean;
 
 clean_all:
-	@make -C  isp clean_all
-	@make -C  teaisp clean_all
-	@make -C  isp_bin  clean_all
-	@make -C  $(ISP_3A_DIR)  clean_all
-	@make -C  isp_algo  clean_all
-	@make -C  $(ISP_COMMON_DIR)/raw_replay  clean_all
-	@make -C  $(ISP_COMMON_DIR)/raw_dump clean_all
+	@$(MAKE) -C  isp clean_all
+	@$(MAKE) -C  teaisp clean_all
+	@$(MAKE) -C  isp_bin  clean_all
+	@$(MAKE) -C  $(ISP_3A_DIR)  clean_all
+	@$(MAKE) -C  isp_algo  clean_all
+	@$(MAKE) -C  $(ISP_COMMON_DIR)/raw_replay  clean_all
+	@$(MAKE) -C  $(ISP_COMMON_DIR)/raw_dump clean_all

--- a/cvi_mpi/modules/isp/cv181x/Makefile
+++ b/cvi_mpi/modules/isp/cv181x/Makefile
@@ -16,7 +16,7 @@ all:
 	@cd isp; $(MAKE) all;
 	@cd isp_bin; $(MAKE) all;
 	@cd $(ISP_COMMON_DIR)/toolJsonGenerator; ./generate_toolJson.sh $(shell echo $(CHIP_ARCH) | tr A-Z a-z)
-	@cd isp-daemon2; $(MAKE) -j4; $(MAKE) install;
+	@cd isp-daemon2; $(MAKE); $(MAKE) install;
 	@cd $(ISP_COMMON_DIR)/raw_replay; $(MAKE) all;
 	@cd $(ISP_COMMON_DIR)/raw_dump; $(MAKE) all;
 
@@ -44,10 +44,10 @@ clean:
 	@cd $(ISP_COMMON_DIR)/raw_dump; $(MAKE) clean;
 
 clean_all:
-	@make -C  isp clean_all
-	@make -C  teaisp clean_all
-	@make -C  isp_bin  clean_all
-	@make -C  $(ISP_3A_DIR)  clean_all
-	@make -C  isp_algo  clean_all
-	@make -C  $(ISP_COMMON_DIR)/raw_replay  clean_all
-	@make -C  $(ISP_COMMON_DIR)/raw_dump clean_all
+	@$(MAKE) -C  isp clean_all
+	@$(MAKE) -C  teaisp clean_all
+	@$(MAKE) -C  isp_bin  clean_all
+	@$(MAKE) -C  $(ISP_3A_DIR)  clean_all
+	@$(MAKE) -C  isp_algo  clean_all
+	@$(MAKE) -C  $(ISP_COMMON_DIR)/raw_replay  clean_all
+	@$(MAKE) -C  $(ISP_COMMON_DIR)/raw_dump clean_all

--- a/cvi_mpi/sample/Makefile
+++ b/cvi_mpi/sample/Makefile
@@ -12,9 +12,7 @@ all:
 	@echo "##############################"
 	@echo $(SUBDIRS) $(MAKECMDGOALS)
 
-	@$(foreach t,$(SUBDIRS), \
-		cd $(t) && $(MAKE) all || exit 1 && cd -; )
+	@for t in $(SUBDIRS); do $(MAKE) -C $$t all || exit 1; done
 
 clean:
-	@$(foreach t,$(SUBDIRS), \
-		cd $(t) && $(MAKE) clean || exit 1 && cd -; )
+	@for t in $(SUBDIRS); do $(MAKE) -C $$t clean || exit 1; done

--- a/cvi_mpi/sample/audio/Makefile
+++ b/cvi_mpi/sample/audio/Makefile
@@ -205,8 +205,8 @@ check_and_leave:
 	@rm -rf $(MW_PATH)/lib/3rd/libmp3lame*
 
 sample_multi_process:
-	cd ./multiprocess_case/down_example; make clean;make
-	cd ./multiprocess_case/up_example; make clean;make
+	cd ./multiprocess_case/down_example; $(MAKE) clean; $(MAKE)
+	cd ./multiprocess_case/up_example; $(MAKE) clean; $(MAKE)
 
 clean:
 	@echo "sample/audio/clean in"  $(MW_PATH)


### PR DESCRIPTION
…heritance

Fixes 'write jobserver: Bad file descriptor' error on macOS/Podman builds.

Changes:
- Makefile: make -> $(MAKE) for sample, module targets
- component/isp/Makefile: pushd/popd -> $(MAKE) -C
- component/isp/sensor/cv18[01]x,cv182x,sg200x/Makefile: MAKE_SENSOR macro pushd/popd -> $(MAKE) -C, add .NOTPARALLEL
- modules/audio/Makefile: cd; make -> $(MAKE) -C
- modules/isp/cv18[01]x/Makefile: hardcoded -j4 removed
- sample/Makefile: foreach cd/make -> for loop with $(MAKE) -C
- sample/audio/Makefile: cd; make -> $(MAKE) -C