### PR TITLE
opensbi: Backport FENCE.TSO emulation fixes for C906 errata

### DIFF
--- a/opensbi/include/sbi/riscv_encoding.h
+++ b/opensbi/include/sbi/riscv_encoding.h
@@ -625,6 +625,9 @@
 #define INSN_MASK_WFI			0xffffff00
 #define INSN_MATCH_WFI			0x10500000
 
+#define INSN_MASK_FENCE_TSO		0xffffffff
+#define INSN_MATCH_FENCE_TSO		0x8330000f
+
 #define INSN_16BIT_MASK			0x3
 #define INSN_32BIT_MASK			0x1c
 

--- a/opensbi/include/sbi/riscv_encoding.h
+++ b/opensbi/include/sbi/riscv_encoding.h
@@ -625,7 +625,7 @@
 #define INSN_MASK_WFI			0xffffff00
 #define INSN_MATCH_WFI			0x10500000
 
-#define INSN_MASK_FENCE_TSO		0xffffffff
+#define INSN_MASK_FENCE_TSO		0xfff0707f
 #define INSN_MATCH_FENCE_TSO		0x8330000f
 
 #define INSN_16BIT_MASK			0x3

--- a/opensbi/lib/sbi/sbi_illegal_insn.c
+++ b/opensbi/lib/sbi/sbi_illegal_insn.c
@@ -8,6 +8,7 @@
  */
 
 #include <sbi/riscv_asm.h>
+#include <sbi/riscv_barrier.h>
 #include <sbi/riscv_encoding.h>
 #include <sbi/sbi_bitops.h>
 #include <sbi/sbi_emulate_csr.h>
@@ -29,6 +30,17 @@ static int truly_illegal_insn(ulong insn, struct sbi_trap_regs *regs)
 	trap.tinst = 0;
 
 	return sbi_trap_redirect(regs, &trap);
+}
+
+static int misc_mem_opcode_insn(ulong insn, struct sbi_trap_regs *regs)
+{
+	/* Errata workaround: emulate `fence.tso` as `fence rw, rw`. */
+	if ((insn & INSN_MASK_FENCE_TSO) == INSN_MATCH_FENCE_TSO) {
+		smp_mb();
+		return 0;
+	}
+
+	return truly_illegal_insn(insn, regs);
 }
 
 static int system_opcode_insn(ulong insn, struct sbi_trap_regs *regs)
@@ -83,7 +95,7 @@ static illegal_insn_func illegal_insn_table[32] = {
 	truly_illegal_insn, /* 0 */
 	truly_illegal_insn, /* 1 */
 	truly_illegal_insn, /* 2 */
-	truly_illegal_insn, /* 3 */
+	misc_mem_opcode_insn, /* 3 */
 	truly_illegal_insn, /* 4 */
 	truly_illegal_insn, /* 5 */
 	truly_illegal_insn, /* 6 */

--- a/opensbi/lib/sbi/sbi_illegal_insn.c
+++ b/opensbi/lib/sbi/sbi_illegal_insn.c
@@ -37,6 +37,7 @@ static int misc_mem_opcode_insn(ulong insn, struct sbi_trap_regs *regs)
 	/* Errata workaround: emulate `fence.tso` as `fence rw, rw`. */
 	if ((insn & INSN_MASK_FENCE_TSO) == INSN_MATCH_FENCE_TSO) {
 		smp_mb();
+		regs->mepc += 4;
 		return 0;
 	}
 


### PR DESCRIPTION
Backport three commits from upstream OpenSBI to fix `FENCE.TSO`
instruction handling on RISC-V C906/C910 cores (Milk-V Duo).

See commit messgaes for details