### PR TITLE
fix(uart): correct hal_uart_getc polling logic

### DIFF
--- a/freertos/cvitek/hal/cv181x/uart/src/hal_uart_dw.c
+++ b/freertos/cvitek/hal/cv181x/uart/src/hal_uart_dw.c
@@ -44,8 +44,9 @@ void hal_uart_putc(uint8_t ch)
 
 int hal_uart_getc(void)
 {
-	while (!(uart->lsr & UART_LSR_DR))
-		return (int)uart->rbr;
+	while (!(uart->lsr & UART_LSR_DR));
+
+	return (int)uart->rbr;
 }
 
 int hal_uart_tstc(void)


### PR DESCRIPTION
## Summary

Fix the polling logic in `hal_uart_getc()` for the DesignWare UART HAL used by CV181x.

## Problem

The previous implementation returned immediately while `UART_LSR_DR` was not set, causing `RBR` to be read before RX data became available.

## Solution

* Keep polling `UART_LSR_DR` until the Data Ready bit is set.
* Read and return the received byte from `RBR` after data is available.

## Affected file

* `cv181x/hal/uart/src/hal_uart_dw.c`

## Testing

* Verified UART receive works correctly in polling mode.
* Confirmed `hal_uart_getc()` blocks until a byte is received.
